### PR TITLE
Server consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .viminfo
 .local/
 .vscode/
+.bash_history
+.viminfo

--- a/httpserver/httpserver.go
+++ b/httpserver/httpserver.go
@@ -54,19 +54,16 @@ func WithOptionalHandlers(handlers ...HandleChainFunc) ServerOption {
 
 // New creates a new httpserver.
 func New(log Logger, name string, port string, h http.Handler, opts ...ServerOption) *Server {
-	s := Server{
-		server: http.Server{
-			Addr: ":" + port,
-		},
-		handler: h,
-		name:    strings.ToLower(name),
+	var s Server
+	s.server = http.Server{
+		Addr: ":" + port,
 	}
+	s.handler = h
+	s.name = strings.ToLower(name)
 	s.log = log.WithIndex("httpserver", s.String())
 	for _, opt := range opts {
 		opt(&s)
 	}
-	// It is preferable to return a copy rather than a reference. Unfortunately http.Server has an
-	// internal mutex and this cannot or should not be copied so we will return a reference instead.
 	return &s
 }
 

--- a/metrics/httpserver.go
+++ b/metrics/httpserver.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/datatrails/go-datatrails-common/httpserver"
+)
+
+type HTTPServer struct {
+	*httpserver.Server
+	metrics *Metrics
+}
+
+func NewServer(log Logger, serviceName string, port string, opts ...MetricsOption) HTTPServer {
+	m := New(
+		log,
+		serviceName,
+		port,
+	)
+	return HTTPServer{
+		httpserver.New(log, fmt.Sprintf("metrics %s", serviceName), port, m.newPromHandler()),
+		m,
+	}
+}
+
+func (h *HTTPServer) Metrics() *Metrics {
+	return h.metrics
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -121,16 +121,9 @@ func (m *Metrics) Register(cs ...prometheus.Collector) {
 	m.registry.MustRegister(cs...)
 }
 
-func (m *Metrics) Port() string {
-	if m != nil {
-		return m.port
-	}
-	return ""
-}
-
 // NewPromHandler - this handler is used on the endpoint that serves metrics endpoint
 // which is provided on a different port to the service.
 // The default InstrumentMetricHandler is suppressed.
-func (m *Metrics) NewPromHandler() http.Handler {
+func (m *Metrics) newPromHandler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
 }


### PR DESCRIPTION

Stuttering removed - GRPCServer renamed to just Server and similarly for http and restproxyserver.

grpcserver now accepts 'port' as an argument instead of getting the value from the environment.

[AB#9031](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9031)