### PR TITLE
Go 1.22

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: Check formatting
         uses: Jerome1337/gofmt-action@v1.0.5
@@ -30,7 +30,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.54
+          version: v1.56
       - name: Install Task
         uses: arduino/setup-task@v1
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,7 @@ linters:
     - gosec
     - gosimple
     - ifshort
+    - inamedparam
     - interfacer
     - interfacebloat
     - ireturn
@@ -166,6 +167,8 @@ linters:
     - nosnakecase
     - nosprintfhostport
     - paralleltest
+    - perfsprint
+    - protogetter
     - prealloc
     - revive
     - rowserrcheck
@@ -175,6 +178,7 @@ linters:
     - tagalign
     - tagliatelle
     - tenv
+    - testifylint
     - testpackage
     - thelper
     - tparallel

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datatrails/go-datatrails-common
 
-go 1.21
+go 1.22
 
 replace github.com/datatrails/go-datatrails-common => ./
 


### PR DESCRIPTION
Use go 1.22.1
Uograde golangci-lint 1.56.2

Upgrading golangci-lint simultaneously is usually required. golangci-lint is go 1.22 caompatible from 1.56.0 onwards.

[AB#9091](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9091)