### PR TITLE
Metrics are always enabled

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/datatrails/go-datatrails-common/environment"
 )
 
 const (
@@ -98,33 +96,19 @@ func WithLabel(label string, offset int) MetricsOption {
 	}
 }
 
-func New(log Logger, serviceName string, opts ...MetricsOption) *Metrics {
-	m := Metrics{
-		log:         log,
-		serviceName: strings.ToLower(serviceName),
-		registry:    prometheus.NewRegistry(),
-		labels:      []latencyObserveOffset{},
-	}
-	for _, opt := range opts {
-		opt(&m)
-	}
-	return &m
+func New(log Logger, serviceName string, port string, opts ...MetricsOption) *Metrics {
+	var m Metrics
+	return new_(&m, log, serviceName, port, opts...)
 }
 
-func NewFromEnvironment(log Logger, serviceName string, opts ...MetricsOption) *Metrics {
-	useMetrics := environment.GetTruthyOrFatal("USE_METRICS")
-	var port string
-	if useMetrics {
-		port = environment.GetOrFatal("METRICS_PORT")
-	}
-	var m *Metrics
-	if port != "" {
-		m = New(
-			log,
-			serviceName,
-			opts...,
-		)
-		m.port = port
+func new_(m *Metrics, log Logger, serviceName string, port string, opts ...MetricsOption) *Metrics {
+	m.log = log
+	m.serviceName = strings.ToLower(serviceName)
+	m.registry = prometheus.NewRegistry()
+	m.labels = []latencyObserveOffset{}
+	m.port = port
+	for _, opt := range opts {
+		opt(m)
 	}
 	return m
 }

--- a/startup/listener.go
+++ b/startup/listener.go
@@ -44,19 +44,6 @@ func WithListeners(listeners ...Listener) ListenersOption {
 	}
 }
 
-// WithOptionalListeners add multiple listeners. Nil listeners will
-// be ignored.
-func WithOptionalListeners(listeners ...Listener) ListenersOption {
-	return func(l *Listeners) {
-		for i := 0; i < len(listeners); i++ {
-			listener := listeners[i]
-			if listener != nil && !reflect.ValueOf(listener).IsNil() {
-				l.listeners = append(l.listeners, listener)
-			}
-		}
-	}
-}
-
 func NewListeners(log Logger, name string, opts ...ListenersOption) Listeners {
 	l := Listeners{name: strings.ToLower(name)}
 	for _, opt := range opts {


### PR DESCRIPTION
Remove metrics.NewFromEnv that uses env variables.

[AB#9124](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9124)