### PR TITLE
store latest key on cosesigner

### DIFF
--- a/azkeys/coseSigner.go
+++ b/azkeys/coseSigner.go
@@ -10,7 +10,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math/big"
@@ -20,30 +22,96 @@ import (
 	"github.com/veraison/go-cose"
 )
 
-// CoseSignerKeyVault is the azure keyvault client for interacting with keyvault keys
+// IdentifiableCoseSigner represents a Cose1 signer that has additional methods to provide
+// sufficient information to verify the signed product (an identifier for the signing key and the
+// public key.)
+type IdentifiableCoseSigner interface {
+	cose.Signer
+	PublicKey() (*ecdsa.PublicKey, error)
+	KeyIdentifier() string
+	KeyLocation() string
+}
+
+// IdentifiableCoseSignerFactory is for creating IdentifiableCoseSigners. The reason for a factory
+// here is that we can always create a fresh instance, capturing the latest key information at that
+// point in time.
+type IdentifiableCoseSignerFactory interface {
+	NewIdentifiableCoseSigner(ctx context.Context) (IdentifiableCoseSigner, error)
+}
+
+// KeyVaultCoseSignerFactory creates instances of our Azure KeyVault implementation of
+// IdentifiableCoseSigner. The keyvault configuration is stored on the object and new instances
+// can be created without caller knowledge of it.
+type KeyVaultCoseSignerFactory struct {
+	keyVaultURL string
+	keyName     string
+}
+
+// NewKeyVaultCoseSignerFactory returns a new instance of the factory, storing the keyvault config
+func NewKeyVaultCoseSignerFactory(keyVaultURL string, keyName string) *KeyVaultCoseSignerFactory {
+	return &KeyVaultCoseSignerFactory{
+		keyVaultURL: keyVaultURL,
+		keyName:     keyName,
+	}
+}
+
+// NewIdentifiableCoseSigner creates a new keyvault configuration that signs with ES384
+// using the latest version of the named key
+func (f *KeyVaultCoseSignerFactory) NewIdentifiableCoseSigner(ctx context.Context) (IdentifiableCoseSigner, error) {
+	hasher := sha256.New()
+	hasher.Write([]byte("azure-keyvault"))
+	locationHash := hasher.Sum(nil)
+	locationHashString := hex.EncodeToString(locationHash)[:6]
+
+	kv := KeyVaultCoseSigner{
+		keyName: f.keyName,
+		alg:     keyvault.ES384, // hardwired for the moment, add caller setting when needed
+		KeyVault: &KeyVault{
+			url: f.keyVaultURL,
+		},
+		locationIdentifier: locationHashString,
+	}
+
+	key, err := kv.GetLatestKey(ctx, kv.keyName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get latest key for %s: %w", kv.keyName, err)
+	}
+
+	if key.Key.Kid == nil {
+		return nil, fmt.Errorf("key ID is nil")
+	}
+
+	kv.key = key
+
+	return &kv, nil
+}
+
+// KeyVaultCoseSigner is the azure keyvault client for interacting with keyvault keys
 // using a cose.Signer interface
-type CoseSignerKeyVault struct {
-	keyName string
-	alg     keyvault.JSONWebKeySignatureAlgorithm
+type KeyVaultCoseSigner struct {
+	keyName            string
+	alg                keyvault.JSONWebKeySignatureAlgorithm
+	key                keyvault.KeyBundle
+	locationIdentifier string
 	*KeyVault
 }
 
-// NewCoseSignerKeyVault creates a new keyvault configuration that signs with ES384
-// using the latest version of the named key
-func NewCoseSignerKeyVault(keyVaultURL string, keyName string) *CoseSignerKeyVault {
-	kv := CoseSignerKeyVault{
-		keyName: keyName,
-		alg:     keyvault.ES384, // hardwired for the moment, add caller setting when needed
-		KeyVault: &KeyVault{
-			url: keyVaultURL,
-		},
-	}
-	return &kv
+// KeyLocation returns an identifier for the place where the key is stored, used by the
+// KeyIdentifier implementation.
+func (kv *KeyVaultCoseSigner) KeyLocation() string {
+	return kv.locationIdentifier
 }
 
 // Algorithm gets the cose algorithm for the key
-func (kv *CoseSignerKeyVault) Algorithm() cose.Algorithm {
+func (kv *KeyVaultCoseSigner) Algorithm() cose.Algorithm {
 	return cose.AlgorithmES384
+}
+
+// KeyIdentifier returns the essential information to identify the key, apart from any platform
+// specific format (i.e. the Azure URL.) It takes the form: <location>:<key name>/<key version>.
+// The location helps us identify where this key is stored. In this case, its azure key vault
+func (kv *KeyVaultCoseSigner) KeyIdentifier() string {
+	return fmt.Sprintf("%s:%s/%s", kv.KeyLocation(), GetKeyName(*kv.key.Key.Kid), GetKeyVersion(*kv.key.Key.Kid))
 }
 
 // base64BEtoBigInt takes a URL Encoded, base 64 encoded big endian byte array
@@ -59,28 +127,20 @@ func base64BEtoBigInt(in string) (*big.Int, error) {
 	return i, nil
 }
 
-// PublicKey gets the latest key's public key
-func (kv *CoseSignerKeyVault) PublicKey() (*ecdsa.PublicKey, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	key, err := kv.GetLatestKey(ctx, kv.keyName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get latest key for %s: %w", kv.keyName, err)
-	}
-
-	if key.Key.X == nil || key.Key.Y == nil {
+// PublicKey returns the public key for this instance of CoseSignerKeyVault
+func (kv *KeyVaultCoseSigner) PublicKey() (*ecdsa.PublicKey, error) {
+	if kv.key.Key.X == nil || kv.key.Key.Y == nil {
 		return nil, fmt.Errorf("public key is nil")
 	}
 
-	X, err := base64BEtoBigInt(*key.Key.X)
+	X, err := base64BEtoBigInt(*kv.key.Key.X)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert X %s: %w", *key.Key.X, err)
+		return nil, fmt.Errorf("unable to convert X %s: %w", *kv.key.Key.X, err)
 	}
 
-	Y, err := base64BEtoBigInt(*key.Key.Y)
+	Y, err := base64BEtoBigInt(*kv.key.Key.Y)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert Y %s: %w", *key.Key.Y, err)
+		return nil, fmt.Errorf("unable to convert Y %s: %w", *kv.key.Key.Y, err)
 	}
 
 	return &ecdsa.PublicKey{
@@ -93,24 +153,14 @@ func (kv *CoseSignerKeyVault) PublicKey() (*ecdsa.PublicKey, error) {
 }
 
 // Sign signs a given content
-func (kv *CoseSignerKeyVault) Sign(rand io.Reader, content []byte) ([]byte, error) {
-
+func (kv *KeyVaultCoseSigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-
-	key, err := kv.GetLatestKey(ctx, kv.keyName)
-	if err != nil {
-		return []byte{}, fmt.Errorf("unable to get latest key for %s: %w", kv.keyName, err)
-	}
-
-	if key.Key.Kid == nil {
-		return []byte{}, fmt.Errorf("key ID is nil")
-	}
 
 	signature, err := kv.KeyVault.HashAndSign(
 		ctx,
 		content,
-		*key.Key.Kid,
+		*kv.key.Key.Kid,
 		kv.alg,
 	)
 	if err != nil {

--- a/azkeys/secretvault.go
+++ b/azkeys/secretvault.go
@@ -12,9 +12,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/datatrails/go-datatrails-common/logger"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (

--- a/azkeys/testCoseSigner.go
+++ b/azkeys/testCoseSigner.go
@@ -1,0 +1,72 @@
+package azkeys
+
+// testCoseSigner.go contains an implementation of the IdentifiableCoseSigner and
+// IdentifiableCoseSignerFactory interfaces to enable unit testing. The actual signing logic is
+// provided by a local COSE signer, wrapped up in a type that conforms to the expectations of the
+// service code.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"io"
+	"testing"
+
+	dtcose "github.com/datatrails/go-datatrails-common/cose"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
+)
+
+type TestCoseSignerFactory struct {
+	t          *testing.T
+	signingKey ecdsa.PrivateKey
+}
+
+func NewTestCoseSignerFactory(t *testing.T, signingKey ecdsa.PrivateKey) IdentifiableCoseSignerFactory {
+	return &TestCoseSignerFactory{
+		t:          t,
+		signingKey: signingKey,
+	}
+}
+
+func (f *TestCoseSignerFactory) NewIdentifiableCoseSigner(ctx context.Context) (IdentifiableCoseSigner, error) {
+	return NewTestCoseSigner(f.t, f.signingKey), nil
+}
+
+// TestCoseSigner implements IdentifiableCoseSigner for use with the factory setup in logconfirmer.
+type TestCoseSigner struct {
+	innerSigner cose.Signer
+	publicKey   ecdsa.PublicKey
+}
+
+func NewTestCoseSigner(t *testing.T, signingKey ecdsa.PrivateKey) *TestCoseSigner {
+	alg, err := dtcose.CoseAlgForEC(signingKey.PublicKey)
+	require.NoError(t, err)
+
+	signer, err := cose.NewSigner(alg, &signingKey)
+	require.NoError(t, err)
+
+	return &TestCoseSigner{
+		innerSigner: signer,
+		publicKey:   signingKey.PublicKey,
+	}
+}
+
+func (s *TestCoseSigner) Algorithm() cose.Algorithm {
+	return s.innerSigner.Algorithm()
+}
+
+func (s *TestCoseSigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
+	return s.innerSigner.Sign(rand, content)
+}
+
+func (s *TestCoseSigner) PublicKey() (*ecdsa.PublicKey, error) {
+	return &s.publicKey, nil
+}
+
+func (s *TestCoseSigner) KeyLocation() string {
+	return "test"
+}
+
+func (s *TestCoseSigner) KeyIdentifier() string {
+	return "foo/bar"
+}

--- a/cose/cose_test.go
+++ b/cose/cose_test.go
@@ -397,7 +397,7 @@ func TestCoseSign1Message_CWTClaimsFromProtectedHeader(t *testing.T) {
 								int64(8): map[interface{}]interface{}{
 									int64(1): map[interface{}]interface{}{
 										int64(-1): "P-384",
-										int64(2):  []byte("testkey"),
+										int64(2):  "testkey",
 										int64(1):  "EC",
 										int64(-2): []byte("QhPk3wbfLoowqrmOewzZVMtQSdC_pMUeOvVxQ7k1-Lojfv2n8buIhGw5znifNLMG"),
 										int64(-3): []byte("AFxaZUbSjVR-qlRPX7WiU72xkkiFyjmautqOYm4BcPURpirIz4ySPTBXNDPQ2ZUW"),

--- a/cose/ec_key.go
+++ b/cose/ec_key.go
@@ -102,5 +102,8 @@ func (ecck *ECCoseKey) PublicKey() (crypto.PublicKey, error) {
 	publicKey.Y = y
 
 	return &publicKey, nil
+}
 
+func (ecck *ECCoseKey) KeyID() []byte {
+	return ecck.Kid
 }

--- a/cose/key.go
+++ b/cose/key.go
@@ -94,9 +94,17 @@ func NewCoseCommonKey(coseKey map[int64]interface{}) (*CoseCommonKey, error) {
 		algoritm = ""
 	}
 
+	// XXX: Type assertions to []byte were failing, hence this.
 	kid := coseKey[KeyIDLabel]
-	// TODO: error handling
-	kidBytes, _ := kid.([]byte)
+	kidString, ok := kid.(string)
+	if !ok {
+		logger.Sugar.Infof("NewCoseCommonKey: failed to interpret KID as string: %v", kid)
+	}
+
+	kidBytes := []byte(kidString)
+	if len(kidBytes) == 0 {
+		kidBytes = nil
+	}
 
 	keyOps := coseKey[KeyOperationsLabel]
 	// TODO: error handling


### PR DESCRIPTION
This paves the way for instantiating a cosesigner each time we want to sign something. The reasoning is that it lets us always get the latest key and have access to the key name and version used. This lets us use the new KeyIdentifier() method to set the Cose Sign1 headers usefully.

re: [AB#9185](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9185)