### PR TITLE
Confirmation Metrics

### DIFF
--- a/errhandling/statuserr.go
+++ b/errhandling/statuserr.go
@@ -61,13 +61,13 @@ func StatusWithQuotaFailure(subject string, label string, name string) *Status {
 
 func IsStatusLimit(err error, label string) bool {
 	st := status.Convert(err)
-	logger.Sugar.Debugf("IsStatusLimit: status %s %s", label, st)
 	for _, detail := range st.Details() {
 		switch v := detail.(type) {
 		case *errdetails.QuotaFailure:
 			for _, violation := range v.GetViolations() {
 				vals := strings.Split(violation.GetDescription(), " ")
 				if len(vals) > 1 && vals[1] == label {
+					logger.Sugar.Debugf("IsStatusLimit: true: status %s %s", label, st)
 					return true
 				}
 			}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -61,19 +61,19 @@ func RequestsLatencyMetric() *prometheus.HistogramVec {
 	)
 }
 
-// create metric according to proof mechanism of ledger or tenant_storage
+// create metric according to proof mechanism of simple hash or merkle log
 // EventsConfirmDurationMetric measures an SLA "95% of all confirmations must be made in less than 5minutes" and to
 // plot average confirmation time and the apdex score.
 // https://www.bookstack.cn/read/prometheus-en/1e87bb1c6ea1f003.md
-// bucket limits are in seconds... and are different for ledger and tenant_storage
+// bucket limits are in seconds... and may be different for simple hash, merkle log or other duration metrics.
 func NewEventsConfirmDurationMetric(name string, buckets []float64) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    fmt.Sprintf("archivist_%sevents_confirmation_duration", name),
-			Help:    "Histogram of time to confirm an event.",
+			Help:    fmt.Sprintf("Histogram of time to confirm a %s event.", name),
 			Buckets: buckets,
 		},
-		[]string{"tenant", "operation"},
+		[]string{"operation"},
 	)
 }
 


### PR DESCRIPTION
The generic confirmation metric only has an 'operation' tag.
The tenant tag has been removed.

[AB#9226](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9226)