### PR TITLE
fix: logging or not is the concern of the azblobs package caller

### DIFF
--- a/azblob/put.go
+++ b/azblob/put.go
@@ -56,7 +56,6 @@ func (azp *Storer) putBlob(
 
 	blockBlobClient, err := azp.containerClient.NewBlockBlobClient(identity)
 	if err != nil {
-		logger.Sugar.Infof("Cannot get block blob client blob: %v", err)
 		return nil, ErrorFromError(err)
 	}
 
@@ -70,7 +69,6 @@ func (azp *Storer) putBlob(
 		},
 	)
 	if err != nil {
-		logger.Sugar.Infof("Cannot upload blob: %v", err)
 		return nil, ErrorFromError(err)
 	}
 	return uploadWriteResponse(r), nil


### PR DESCRIPTION
Putting info logs in anything in go-datatrails-common is generally a bad idea. At least in high frequency operations, which most things in here are.

[AB#9287](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9287)