### PR TITLE
Receive Messages Serially

### DIFF
--- a/azbus/disposition.go
+++ b/azbus/disposition.go
@@ -51,8 +51,6 @@ func (r *Receiver) dispose(ctx context.Context, d Disposition, err error, msg *R
 	}
 }
 
-// NB: ALL disposition methods return nil so they can be used in return statements
-
 // Abandon abandons message. This function is not used but is present for consistency.
 func (r *Receiver) abandon(ctx context.Context, err error, msg *ReceivedMessage) {
 	ctx = context.WithoutCancel(ctx)

--- a/azbus/tracing.go
+++ b/azbus/tracing.go
@@ -8,7 +8,7 @@ import (
 
 func (r *Receiver) handleReceivedMessageWithTracingContext(ctx context.Context, message *ReceivedMessage, handler Handler) (Disposition, context.Context, error) {
 	// We don't have the tracing span info on the context yet, that is what this function will add
-	// we we log using the reciever logger
+	// we log using the receiver logger
 	r.log.Debugf("ContextFromReceivedMessage(): ApplicationProperties %v", message.ApplicationProperties)
 
 	var opts = []opentracing.StartSpanOption{}
@@ -34,6 +34,40 @@ func (r *Receiver) handleReceivedMessageWithTracingContext(ctx context.Context, 
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	return handler.Handle(ctx, message)
+}
+
+func (r *Receiver) handleReceivedMessagesWithTracingContext(ctx context.Context, messages []*ReceivedMessage, handler BatchHandler) ([]Disposition, context.Context, error) {
+
+	var opts = []opentracing.StartSpanOption{}
+	carrier := opentracing.TextMapCarrier{}
+	// This just gets all the message Application Properties into a string map. That map is then passed into the
+	// open tracing constructor which extracts any bits it is interested in to use to setup the spans etc.
+	// It will ignore anything it doesn't care about. So the filtering of the map is done for us and
+	// we don't need to pre-filter it.
+
+	// We don't have the tracing span info on the context yet, that is what this function will add
+	// we log using the receiver logger
+	// only use first message for tracing..... will fix later
+	msg := messages[0]
+	r.log.Debugf("ContextFromReceivedMessage(): ApplicationProperties %v", msg.ApplicationProperties)
+
+	for k, v := range msg.ApplicationProperties {
+		// Tracing properties will be strings
+		value, ok := v.(string)
+		if ok {
+			carrier.Set(k, value)
+		}
+	}
+	spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, carrier)
+	if err != nil {
+		r.log.Infof("handleReceivedMessageWithTracingContext(): Unable to extract span context: %v", err)
+	} else {
+		opts = append(opts, opentracing.ChildOf(spanCtx))
+	}
+	span := opentracing.StartSpan("handle message", opts...)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	return handler.Handle(ctx, messages)
 }
 
 func (s *Sender) updateSendingMesssageForSpan(ctx context.Context, message *OutMessage, span opentracing.Span) {

--- a/taskfiles/Taskfile_codeqa.yml
+++ b/taskfiles/Taskfile_codeqa.yml
@@ -27,17 +27,18 @@ tasks:
     desc: Quality assurance of code
     summary: "format sources (go fmt)"
     cmds:
-      - gofmt -l -s -w .
+      - |
+        go fix ./...
+        goimports -w .
+        gofmt -l -s -w .
 
   lint:
     desc: Quality assurance of code
     cmds:
       - |
-        golangci-lint --version
         go vet ./...
-        goimports {{.VERBOSE}} -w .
+        golangci-lint --version
         golangci-lint {{.VERBOSE}} run --timeout 10m ./...
-        gofmt -l -s -w .
 
   unit-tests:
     desc: "run unit tests"


### PR DESCRIPTION
New functional option to add a serialHandler that reads N messages at
once and process them one at a time - serially.

    receiver := NewReceiver(, WithSerialHandler(h, 200))

where h is an instance of Handler.

Defining a SerialHandler this way disables the normal parallel
processing defined by WithHandlers().

It is highly recommended to specify RenewMessageLock if the number of
received messages is high (say > 10). One has to be sure that processing
the number of messages within 60s is achievable.


[AB#9378](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9378)