### PR TITLE
Remove tenant id from metrics

### DIFF
--- a/azbus/mocks/Handler.go
+++ b/azbus/mocks/Handler.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
-	context "context"
-
+	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	azbus "github.com/datatrails/go-datatrails-common/azbus"
+
+	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -56,22 +57,26 @@ func (_c *Handler_Close_Call) RunAndReturn(run func()) *Handler_Close_Call {
 }
 
 // Handle provides a mock function with given fields: _a0, _a1
-func (_m *Handler) Handle(_a0 context.Context, _a1 *azbus.ReceivedMessage) (azbus.Disposition, context.Context, error) {
+func (_m *Handler) Handle(_a0 context.Context, _a1 *azservicebus.ReceivedMessage) (azbus.Disposition, context.Context, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Handle")
+	}
 
 	var r0 azbus.Disposition
 	var r1 context.Context
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, *azbus.ReceivedMessage) (azbus.Disposition, context.Context, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *azservicebus.ReceivedMessage) (azbus.Disposition, context.Context, error)); ok {
 		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *azbus.ReceivedMessage) azbus.Disposition); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *azservicebus.ReceivedMessage) azbus.Disposition); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(azbus.Disposition)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *azbus.ReceivedMessage) context.Context); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *azservicebus.ReceivedMessage) context.Context); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		if ret.Get(1) != nil {
@@ -79,7 +84,7 @@ func (_m *Handler) Handle(_a0 context.Context, _a1 *azbus.ReceivedMessage) (azbu
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, *azbus.ReceivedMessage) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, *azservicebus.ReceivedMessage) error); ok {
 		r2 = rf(_a0, _a1)
 	} else {
 		r2 = ret.Error(2)
@@ -95,14 +100,14 @@ type Handler_Handle_Call struct {
 
 // Handle is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 *azbus.ReceivedMessage
+//   - _a1 *azservicebus.ReceivedMessage
 func (_e *Handler_Expecter) Handle(_a0 interface{}, _a1 interface{}) *Handler_Handle_Call {
 	return &Handler_Handle_Call{Call: _e.mock.On("Handle", _a0, _a1)}
 }
 
-func (_c *Handler_Handle_Call) Run(run func(_a0 context.Context, _a1 *azbus.ReceivedMessage)) *Handler_Handle_Call {
+func (_c *Handler_Handle_Call) Run(run func(_a0 context.Context, _a1 *azservicebus.ReceivedMessage)) *Handler_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*azbus.ReceivedMessage))
+		run(args[0].(context.Context), args[1].(*azservicebus.ReceivedMessage))
 	})
 	return _c
 }
@@ -112,7 +117,7 @@ func (_c *Handler_Handle_Call) Return(_a0 azbus.Disposition, _a1 context.Context
 	return _c
 }
 
-func (_c *Handler_Handle_Call) RunAndReturn(run func(context.Context, *azbus.ReceivedMessage) (azbus.Disposition, context.Context, error)) *Handler_Handle_Call {
+func (_c *Handler_Handle_Call) RunAndReturn(run func(context.Context, *azservicebus.ReceivedMessage) (azbus.Disposition, context.Context, error)) *Handler_Handle_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -120,6 +125,10 @@ func (_c *Handler_Handle_Call) RunAndReturn(run func(context.Context, *azbus.Rec
 // Open provides a mock function with given fields:
 func (_m *Handler) Open() error {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Open")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {

--- a/azbus/mocks/MsgReceiver.go
+++ b/azbus/mocks/MsgReceiver.go
@@ -27,6 +27,10 @@ func (_m *MsgReceiver) EXPECT() *MsgReceiver_Expecter {
 func (_m *MsgReceiver) GetAZClient() azbus.AZClient {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAZClient")
+	}
+
 	var r0 azbus.AZClient
 	if rf, ok := ret.Get(0).(func() azbus.AZClient); ok {
 		r0 = rf()
@@ -67,6 +71,10 @@ func (_c *MsgReceiver_GetAZClient_Call) RunAndReturn(run func() azbus.AZClient) 
 // Listen provides a mock function with given fields:
 func (_m *MsgReceiver) Listen() error {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Listen")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
@@ -109,6 +117,10 @@ func (_c *MsgReceiver_Listen_Call) RunAndReturn(run func() error) *MsgReceiver_L
 func (_m *MsgReceiver) Shutdown(_a0 context.Context) error {
 	ret := _m.Called(_a0)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Shutdown")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(_a0)
@@ -150,6 +162,10 @@ func (_c *MsgReceiver_Shutdown_Call) RunAndReturn(run func(context.Context) erro
 // String provides a mock function with given fields:
 func (_m *MsgReceiver) String() string {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {

--- a/azbus/mocks/MsgSender.go
+++ b/azbus/mocks/MsgSender.go
@@ -3,9 +3,10 @@
 package mocks
 
 import (
-	context "context"
-
+	azservicebus "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
 	azbus "github.com/datatrails/go-datatrails-common/azbus"
+
+	context "context"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -60,6 +61,10 @@ func (_c *MsgSender_Close_Call) RunAndReturn(run func(context.Context)) *MsgSend
 func (_m *MsgSender) GetAZClient() azbus.AZClient {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAZClient")
+	}
+
 	var r0 azbus.AZClient
 	if rf, ok := ret.Get(0).(func() azbus.AZClient); ok {
 		r0 = rf()
@@ -101,6 +106,10 @@ func (_c *MsgSender_GetAZClient_Call) RunAndReturn(run func() azbus.AZClient) *M
 func (_m *MsgSender) Open() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Open")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -139,11 +148,15 @@ func (_c *MsgSender_Open_Call) RunAndReturn(run func() error) *MsgSender_Open_Ca
 }
 
 // Send provides a mock function with given fields: _a0, _a1
-func (_m *MsgSender) Send(_a0 context.Context, _a1 *azbus.OutMessage) error {
+func (_m *MsgSender) Send(_a0 context.Context, _a1 *azservicebus.Message) error {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Send")
+	}
+
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *azbus.OutMessage) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *azservicebus.Message) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)
@@ -159,14 +172,14 @@ type MsgSender_Send_Call struct {
 
 // Send is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 *azbus.OutMessage
+//   - _a1 *azservicebus.Message
 func (_e *MsgSender_Expecter) Send(_a0 interface{}, _a1 interface{}) *MsgSender_Send_Call {
 	return &MsgSender_Send_Call{Call: _e.mock.On("Send", _a0, _a1)}
 }
 
-func (_c *MsgSender_Send_Call) Run(run func(_a0 context.Context, _a1 *azbus.OutMessage)) *MsgSender_Send_Call {
+func (_c *MsgSender_Send_Call) Run(run func(_a0 context.Context, _a1 *azservicebus.Message)) *MsgSender_Send_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*azbus.OutMessage))
+		run(args[0].(context.Context), args[1].(*azservicebus.Message))
 	})
 	return _c
 }
@@ -176,7 +189,7 @@ func (_c *MsgSender_Send_Call) Return(_a0 error) *MsgSender_Send_Call {
 	return _c
 }
 
-func (_c *MsgSender_Send_Call) RunAndReturn(run func(context.Context, *azbus.OutMessage) error) *MsgSender_Send_Call {
+func (_c *MsgSender_Send_Call) RunAndReturn(run func(context.Context, *azservicebus.Message) error) *MsgSender_Send_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -184,6 +197,10 @@ func (_c *MsgSender_Send_Call) RunAndReturn(run func(context.Context, *azbus.Out
 // String provides a mock function with given fields:
 func (_m *MsgSender) String() string {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for String")
+	}
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {

--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/datatrails/go-datatrails-common/tenantid"
 )
 
 // Tailored Prometheus metrics
@@ -53,21 +51,9 @@ func (m *Metrics) NewLatencyMetricsHandler(h http.Handler) http.Handler {
 
 		latency := time.Since(start).Seconds()
 
-		header := lrw.Header()
-
 		// generate post-process metrics here...
 
-		// tenantID
-		// TODO: when we put the tenant ID in the JWT we can get rid of these
-		// odd header arrangements
-		var tenant string
-		tenantID := tenantid.GetTenantIDFromHeader(header)
-		if tenantID != "" {
-			log.Debugf("tenant ID %s", tenantID)
-			tenant = strings.TrimPrefix(tenantID, tenantid.Prefix)
-			tenantid.DeleteTenantIDFromHeader(header)
-		}
-		observer.ObserveRequestsCount(fields, r.Method, tenant)
-		observer.ObserveRequestsLatency(latency, fields, r.Method, tenant)
+		observer.ObserveRequestsCount(fields, r.Method)
+		observer.ObserveRequestsLatency(latency, fields, r.Method)
 	})
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,9 +18,9 @@ func CosmosChargeMetric() *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "archivist_cosmos_charge",
-			Help: "Cosmos charge by tenant, method and resource.",
+			Help: "Cosmos charge by method and resource.",
 		},
-		[]string{"tenant", "method", "resource"},
+		[]string{"method", "resource"},
 	)
 }
 
@@ -29,9 +29,9 @@ func CosmosDurationMetric() *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "archivist_cosmos_duration",
-			Help: "Cosmos duration by tenant, method and resource.",
+			Help: "Cosmos duration by method and resource.",
 		},
-		[]string{"tenant", "method", "resource"},
+		[]string{"method", "resource"},
 	)
 }
 
@@ -40,9 +40,9 @@ func RequestsCounterMetric() *prometheus.CounterVec {
 	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "archivist_requests_total",
-			Help: "Total number of requests by method, tenant, service and resource.",
+			Help: "Total number of requests by method, service and resource.",
 		},
-		[]string{"method", "tenant", "service", "resource"},
+		[]string{"method", "service", "resource"},
 	)
 }
 
@@ -57,7 +57,7 @@ func RequestsLatencyMetric() *prometheus.HistogramVec {
 			Help:    "Histogram of time to reply to request.",
 			Buckets: []float64{.005, .01, .02, .04, .08, .16, .32},
 		},
-		[]string{"method", "tenant", "service", "resource"},
+		[]string{"method", "service", "resource"},
 	)
 }
 

--- a/metrics/observers.go
+++ b/metrics/observers.go
@@ -38,23 +38,23 @@ func NewLatencyObservers(m *Metrics) LatencyObservers {
 	return o
 }
 
-func (o *LatencyObservers) ObserveRequestsCount(fields []string, method string, tenant string) {
+func (o *LatencyObservers) ObserveRequestsCount(fields []string, method string) {
 
 	for _, label := range o.labels {
 		if len(fields) > label.offset && fields[label.offset] == label.label {
-			o.log.Infof("Count %s: %s, %s", label.label, method, tenant)
-			o.requestsCounter.WithLabelValues(method, tenant, o.serviceName, label.label).Inc()
+			o.log.Infof("Count %s: %s", label.label, method)
+			o.requestsCounter.WithLabelValues(method, o.serviceName, label.label).Inc()
 			return
 		}
 	}
 }
 
-func (o *LatencyObservers) ObserveRequestsLatency(elapsed float64, fields []string, method string, tenant string) {
+func (o *LatencyObservers) ObserveRequestsLatency(elapsed float64, fields []string, method string) {
 
 	for _, label := range o.labels {
 		if len(fields) > label.offset && fields[label.offset] == label.label {
-			o.log.Infof("Latency %v %s: %s, %s", elapsed, label.label, method, tenant)
-			o.requestsLatency.WithLabelValues(method, tenant, o.serviceName, label.label).Observe(elapsed)
+			o.log.Infof("Latency %v %s: %s", elapsed, label.label, method)
+			o.requestsLatency.WithLabelValues(method, o.serviceName, label.label).Observe(elapsed)
 			return
 		}
 	}

--- a/startup/run.go
+++ b/startup/run.go
@@ -25,7 +25,7 @@ func Run(serviceName string, run Runner) {
 		}
 		err := run(serviceName, log)
 		if err != nil {
-			log.Infof("Error terminating: %v", err)
+			log.Infof("Error at startup: %v", err)
 			exitCode = 1
 		}
 		return exitCode


### PR DESCRIPTION
The tenantid is no longer a label on latency metrics.   
    
Additionally corrected the generated mocks for azbus.

[AB#8906](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8906)

