### PR TITLE
Dev/robin/9402 blob tags to facilitate efficient batch signing

### DIFF
--- a/azblob/list.go
+++ b/azblob/list.go
@@ -12,41 +12,80 @@ import (
 )
 
 // Count counts the number of blobs filtered by the given tags filter
-func (azp *Storer) Count(ctx context.Context, tagsFilter string) (int64, error) {
+func (azp *Storer) Count(ctx context.Context, tagsFilter string, opts ...Option) (int64, error) {
 
 	logger.Sugar.Debugf("Count")
 
-	blobs, err := azp.FilteredList(ctx, tagsFilter)
+	r, err := azp.FilteredList(ctx, tagsFilter, opts...)
 	if err != nil {
 		return 0, err
 	}
 
-	return int64(len(blobs)), nil
+	return int64(len(r.Items)), nil
+}
+
+type FilterResponse struct {
+	Marker ListMarker // nil if no more pages
+
+	// Standard request status things
+	StatusCode int // For If- header fails, err can be nil and code can be 304
+	Status     string
+
+	Items []*azStorageBlob.FilterBlobItem
 }
 
 // FilteredList returns a list of blobs filtered on their tag values.
 //
-// tagsFilter example: "dog='germanshepherd' and penguin='emperorpenguin'"
-// Returns all blobs with the specific tag filter
-func (azp *Storer) FilteredList(ctx context.Context, tagsFilter string) ([]*azStorageBlob.FilterBlobItem, error) {
-	logger.Sugar.Debugf("FilteredList")
+// tagsFilter examples:
+//
+//	All blobs in a storage account
+//		"cat='tiger' AND penguin='emperorpenguin'"
+//	All blobs in a specific container
+//		"@container='zoo' AND cat='tiger' AND penguin='emperorpenguin'"
+//
+// Returns all blobs with the specific tag filter.
+func (azp *Storer) FilteredList(ctx context.Context, tagsFilter string, opts ...Option) (*FilterResponse, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx, "FilteredList")
+	defer span.Finish()
 
-	var filteredBlobs []*azStorageBlob.FilterBlobItem
 	var err error
 
-	result, err := azp.serviceClient.FindBlobsByTags(
-		ctx,
-		&azStorageBlob.ServiceFilterBlobsOptions{
-			Where: &tagsFilter,
-		},
-	)
-	if err != nil {
-		return filteredBlobs, err
+	options := &StorerOptions{}
+	for _, opt := range opts {
+		opt(options)
 	}
 
-	filteredBlobs = result.Blobs
+	if options.listMarker != nil {
+		span.SetTag("marker", *options.listMarker)
+	}
+	o := &azStorageBlob.ServiceFilterBlobsOptions{
+		Marker: options.listMarker,
+		Where:  &tagsFilter,
+	}
 
-	return filteredBlobs, err
+	if options.listMaxResults > 0 {
+		o.MaxResults = &options.listMaxResults
+		span.SetTag("maxResults", options.listMaxResults)
+	}
+
+	resp, err := azp.serviceClient.FindBlobsByTags(ctx, o)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &FilterResponse{
+		StatusCode: resp.RawResponse.StatusCode,
+		Status:     resp.RawResponse.Status,
+		Marker:     resp.NextMarker,
+		Items:      resp.Blobs,
+	}
+
+	r.Marker = resp.NextMarker
+	if r.Marker != nil {
+		span.SetTag("nextmarker", *r.Marker)
+	}
+
+	return r, err
 }
 
 type ListerResponse struct {

--- a/azblob/list.go
+++ b/azblob/list.go
@@ -38,10 +38,22 @@ type FilterResponse struct {
 //
 // tagsFilter examples:
 //
-//	All blobs in a storage account
-//		"cat='tiger' AND penguin='emperorpenguin'"
-//	All blobs in a specific container
-//		"@container='zoo' AND cat='tiger' AND penguin='emperorpenguin'"
+//		 All tenants with more than one massif
+//		     "firstindex">'0000000000000000'
+//
+//		 All tenants whose logs have been updated since a particular idtimestamp
+//		     "lastid > '018e84dbbb6513a6'"
+//
+//	 note: in the case where you are making up the id timestamp from a time
+//	 reading, set the least significant 24 bits to zero and use the hex encoding
+//	 of the resulting value
+//
+//		All blobs in a storage account
+//			"cat='tiger' AND penguin='emperorpenguin'"
+//		All blobs in a specific container
+//			"@container='zoo' AND cat='tiger' AND penguin='emperorpenguin'"
+//
+// See also: https://learn.microsoft.com/en-us/rest/api/storageservices/find-blobs-by-tags-container?tabs=microsoft-entra-id
 //
 // Returns all blobs with the specific tag filter.
 func (azp *Storer) FilteredList(ctx context.Context, tagsFilter string, opts ...Option) (*FilterResponse, error) {

--- a/azblob/reader.go
+++ b/azblob/reader.go
@@ -20,7 +20,7 @@ type Reader interface {
 		identity string,
 		opts ...Option,
 	) (*ReaderResponse, error)
-
+	FilteredList(ctx context.Context, tagsFilter string, opts ...Option) (*FilterResponse, error)
 	List(ctx context.Context, opts ...Option) (*ListerResponse, error)
 }
 

--- a/azblob/storerazurite.go
+++ b/azblob/storerazurite.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/datatrails/go-datatrails-common/logger"
@@ -74,6 +75,9 @@ func NewDev(cfg DevConfig, container string) (*Storer, error) {
 		return nil, err
 	}
 
+	// normalise trailing slash
+	cfg.URL = strings.TrimSuffix(cfg.URL, "/") + "/"
+
 	azp := &Storer{
 		AccountName:   cfg.AccountName,
 		ResourceGroup: azuriteResourceGroup, // just for logging
@@ -84,9 +88,7 @@ func NewDev(cfg DevConfig, container string) (*Storer, error) {
 	}
 
 	azp.containerURL = fmt.Sprintf(
-		"%s%s",
-		cfg.URL,
-		container,
+		"%s%s", cfg.URL, container,
 	)
 	azp.serviceClient, err = azStorageBlob.NewServiceClientWithSharedKey(
 		cfg.URL,


### PR DESCRIPTION
This pr adds suport for filtering blobs accross an entire storage account, or in a particular container, by the tag values on the blob. This should offer an efficient way to batch process events for sealing and enable a straight forward way to support "latests changes" api for partners like true north.

This also facilitates storage account wide lifecycle management based on the idtimestamp value in the tags on the massif blobs: https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview#lifecycle-management-rule-definition

Note that the emulator does not support filtering by tags so it was not possible to add azurite based tests. We have a minimal systemtest on the forestrie side and will supliment that as we restore the batch sealing.

Tests run:

Peformed all the code quality checks in this repo

Added a minimal system test in the forestrie repo which shows that the filter query built by this change lists the correct blobs.

