### PR TITLE
feat: supports our public proxy urls

### DIFF
--- a/azblob/reader.go
+++ b/azblob/reader.go
@@ -26,7 +26,17 @@ type Reader interface {
 
 // NewReaderNoAuth is a azure blob reader client that has no credentials.
 //
+// The provided accountName is only used for logging purposes and may be empty
+// The pro
+//
+// Paramaters:
+//
+//	accountName: used only for logging purposes and may be empty
+//	url: The root path for the blob store requests, must not be empty
+//	container: To use the container client this must be provided. If absent only storage account level apis can be used
+//
 // NOTE: due to having no credentials, this can only read from public blob storage.
+// or proxied private blob storage.
 //
 // example:
 //
@@ -35,23 +45,35 @@ type Reader interface {
 //	container: merklebuilder
 func NewReaderNoAuth(accountName string, url string, container string) (Reader, error) {
 	logger.Sugar.Infof(
-		"New Reader with accountName: %s, for container: %s",
-		accountName, container,
+		"New Reader for url: %s, with accountName: %s, for container: %s",
+		url, accountName, container,
 	)
 
 	var err error
-
-	if accountName == "" || url == "" {
-		return nil, errors.New("missing connection configuration variables")
+	if url == "" {
+		return nil, errors.New("url is a required parameter and cannot be empty")
 	}
 
 	azp := &Storer{
-		AccountName:   accountName,
-		ResourceGroup: "", // just for logging
-		Subscription:  "", // just for logging
+		AccountName:   accountName, // just for logging
+		ResourceGroup: "",          // just for logging
+		Subscription:  "",          // just for logging
 		Container:     container,
 		credential:    nil,
 		rootURL:       url,
+	}
+	azp.serviceClient, err = azStorageBlob.NewServiceClientWithNoCredential(
+		url,
+		nil,
+	)
+	if err != nil {
+		logger.Sugar.Infof("unable to create serviceclient %s: %v", url, err)
+		return nil, err
+	}
+
+	if container == "" {
+		logger.Sugar.Infof("container not provided, container client not created")
+		return nil, nil
 	}
 
 	azp.containerURL = fmt.Sprintf(
@@ -59,14 +81,6 @@ func NewReaderNoAuth(accountName string, url string, container string) (Reader, 
 		url,
 		container,
 	)
-	azp.serviceClient, err = azStorageBlob.NewServiceClientWithNoCredential(
-		url,
-		nil,
-	)
-	if err != nil {
-		logger.Sugar.Infof("unable to create serviceclient %s: %v", azp.containerURL, err)
-		return nil, err
-	}
 	azp.containerClient, err = azp.serviceClient.NewContainerClient(container)
 	if err != nil {
 		logger.Sugar.Infof("unable to create containerclient %s: %v", container, err)


### PR DESCRIPTION
The construction of the rest endpoint domain from the account name is incompatible with our new public proxy url scheme. This change updates the connection configuration support so it is compatible with our forestrie tooling.

[AB#9402](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9402)