### PR TITLE
Use grpc.NewClient

### DIFF
--- a/grpcclient/client.go
+++ b/grpcclient/client.go
@@ -21,7 +21,7 @@ func (g *Client) Open() error {
 	var conn *grpc.ClientConn
 
 	g.log.Debugf("Open %s client at %v", g.name, g.address)
-	conn, err = grpc.Dial(g.address, g.options...) //nolint:staticcheck
+	conn, err = grpc.NewClient(g.address, g.options...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
grpc.Dial is deprecated.

Test results:

    All systemtests pass except for the 2 expected blobs caps tests

[AB#9784](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9784)