### PR TITLE
Upgrade dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# refer: https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
 version: 2
 registries:
   github-octocat:
@@ -15,6 +16,8 @@ updates:
     schedule:
       # Check for updates managed by Composer once a week
       interval: "weekly"
+      day: "sunday"
+      time: "16:00"
 
   # Maintain dependencies for Golang
   - package-ecosystem: "gomod"
@@ -24,3 +27,5 @@ updates:
     schedule:
       # Check for updates managed by Composer once a week
       interval: "weekly"
+      day: "sunday"
+      time: "16:00"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,4 @@
-name: Quality Control
+name: push
 
 on: [pull_request]
 


### PR DESCRIPTION
non-functional

Yaml stanzas are copied from github's master copy at 

     https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml

The integrity of dependabot.yml is checked by github on every push.
Tested by pushing changes and checking that the correct actions were required.

[AB#10361](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10361)