### PR TITLE
Optional tracing in azblob

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-  schedule: # every Tuesday at 3 a.m UTC
-    - cron '0 3 * * 2'
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/azblob/download.go
+++ b/azblob/download.go
@@ -27,6 +27,8 @@ func (azp *Storer) getTags(
 	identity string,
 ) (map[string]string, error) {
 
+	azp.log.Debugf("getTags: %s", identity)
+
 	var err error
 
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
@@ -51,6 +53,8 @@ func (azp *Storer) getMetadata(
 	identity string,
 ) (map[string]string, error) {
 
+	azp.log.Debugf("getMetadata: %s", identity)
+
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
 	if err != nil {
 		return nil, ErrorFromError(err)
@@ -70,6 +74,8 @@ func (azp *Storer) Reader(
 	identity string,
 	opts ...Option,
 ) (*ReaderResponse, error) {
+
+	azp.log.Debugf("Reader: %s", identity)
 
 	var err error
 

--- a/azblob/download.go
+++ b/azblob/download.go
@@ -27,8 +27,6 @@ func (azp *Storer) getTags(
 	identity string,
 ) (map[string]string, error) {
 
-	azp.log.Debugf("getTags: %s", identity)
-
 	var err error
 
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
@@ -53,8 +51,6 @@ func (azp *Storer) getMetadata(
 	identity string,
 ) (map[string]string, error) {
 
-	azp.log.Debugf("getMetadata: %s", identity)
-
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
 	if err != nil {
 		return nil, ErrorFromError(err)
@@ -74,8 +70,6 @@ func (azp *Storer) Reader(
 	identity string,
 	opts ...Option,
 ) (*ReaderResponse, error) {
-
-	azp.log.Debugf("Reader: %s", identity)
 
 	var err error
 

--- a/azblob/error.go
+++ b/azblob/error.go
@@ -56,7 +56,7 @@ func (e *Error) StatusCode() int {
 		logger.Sugar.Debugf("Return statusCode %d", e.statusCode)
 		return e.statusCode
 	}
-	logger.Sugar.Debugf("Return InternalServerError")
+	logger.Sugar.Debugf("Return InternalServerError: %v", e)
 	return http.StatusInternalServerError
 }
 

--- a/azblob/error.go
+++ b/azblob/error.go
@@ -49,14 +49,14 @@ func (e *Error) StatusCode() int {
 		if resp.Body != nil {
 			defer resp.Body.Close()
 		}
-		logger.Sugar.Debugf("Azblob StatusCode %d", resp.StatusCode)
+		logger.Sugar.Debugf("AZBlob downstream statusCode %d", resp.StatusCode)
 		return resp.StatusCode
 	}
 	if e.statusCode != 0 {
-		logger.Sugar.Debugf("Return statusCode %d", e.statusCode)
+		logger.Sugar.Debugf("AZBlob internal statusCode %d", e.statusCode)
 		return e.statusCode
 	}
-	logger.Sugar.Debugf("Return InternalServerError: %v", e)
+	logger.Sugar.Debugf("AZBlob InternalServerError: %v", e)
 	return http.StatusInternalServerError
 }
 

--- a/azblob/reader.go
+++ b/azblob/reader.go
@@ -44,7 +44,7 @@ type Reader interface {
 // example:
 //
 //	url: https://app.datatrails.ai/verifiabledata
-func NewReaderNoAuth(url string, opts ...ReaderOption) (Reader, error) {
+func NewReaderNoAuth(log Logger, url string, opts ...ReaderOption) (Reader, error) {
 	var err error
 	if url == "" {
 		return nil, errors.New("url is a required parameter and cannot be empty")
@@ -53,12 +53,14 @@ func NewReaderNoAuth(url string, opts ...ReaderOption) (Reader, error) {
 	readerOptions := ParseReaderOptions(opts...)
 
 	azp := &Storer{
-		AccountName:   readerOptions.accountName, // just for logging
-		ResourceGroup: "",                        // just for logging
-		Subscription:  "",                        // just for logging
-		Container:     readerOptions.container,
-		credential:    nil,
-		rootURL:       url,
+		AccountName:          readerOptions.accountName, // just for logging
+		ResourceGroup:        "",                        // just for logging
+		Subscription:         "",                        // just for logging
+		Container:            readerOptions.container,
+		credential:           nil,
+		rootURL:              url,
+		startSpanFromContext: readerOptions.startSpanFromContext,
+		log:                  log,
 	}
 
 	azp.serviceClient, err = azStorageBlob.NewServiceClientWithNoCredential(
@@ -93,7 +95,7 @@ func NewReaderNoAuth(url string, opts ...ReaderOption) (Reader, error) {
 
 // NewReaderDefaultAuth is a azure blob reader client that obtains credentials from the
 // environment - including aad pod identity / workload identity.
-func NewReaderDefaultAuth(url string, opts ...ReaderOption) (Reader, error) {
+func NewReaderDefaultAuth(log Logger, url string, opts ...ReaderOption) (Reader, error) {
 	var err error
 	if url == "" {
 		return nil, errors.New("url is a required parameter and cannot be empty")
@@ -102,12 +104,14 @@ func NewReaderDefaultAuth(url string, opts ...ReaderOption) (Reader, error) {
 	readerOptions := ParseReaderOptions(opts...)
 
 	azp := &Storer{
-		AccountName:   readerOptions.accountName, // just for logging
-		ResourceGroup: "",                        // just for logging
-		Subscription:  "",                        // just for logging
-		Container:     readerOptions.container,
-		credential:    nil,
-		rootURL:       url,
+		AccountName:          readerOptions.accountName, // just for logging
+		ResourceGroup:        "",                        // just for logging
+		Subscription:         "",                        // just for logging
+		Container:            readerOptions.container,
+		credential:           nil,
+		rootURL:              url,
+		startSpanFromContext: readerOptions.startSpanFromContext,
+		log:                  log,
 	}
 
 	credentials, err := azidentity.NewDefaultAzureCredential(nil)

--- a/azblob/readeroptions.go
+++ b/azblob/readeroptions.go
@@ -7,6 +7,8 @@ type ReaderOptions struct {
 	accountName string
 
 	container string
+
+	startSpanFromContext startSpanFromContextFunc
 }
 
 type ReaderOption func(*ReaderOptions)
@@ -22,6 +24,12 @@ func WithAccountName(accountName string) ReaderOption {
 func WithContainer(container string) ReaderOption {
 	return func(a *ReaderOptions) {
 		a.container = container
+	}
+}
+
+func WithReaderSpanFromContext(s startSpanFromContextFunc) ReaderOption {
+	return func(a *ReaderOptions) {
+		a.startSpanFromContext = s
 	}
 }
 

--- a/azblob/spanner.go
+++ b/azblob/spanner.go
@@ -1,0 +1,12 @@
+package azblob
+
+import (
+	"context"
+
+	"github.com/datatrails/go-datatrails-common/logger"
+	"github.com/datatrails/go-datatrails-common/spanner"
+)
+
+type Spanner = spanner.Spanner
+
+type startSpanFromContextFunc func(context.Context, logger.Logger, string) (spanner.Spanner, context.Context)

--- a/azblob/storerazurite.go
+++ b/azblob/storerazurite.go
@@ -85,6 +85,7 @@ func NewDev(cfg DevConfig, container string) (*Storer, error) {
 		Container:     container,
 		credential:    cred,
 		rootURL:       cfg.URL,
+		log:           logger.Sugar,
 	}
 
 	azp.containerURL = fmt.Sprintf(

--- a/azblob/upload.go
+++ b/azblob/upload.go
@@ -17,8 +17,6 @@ import (
 
 	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	mimetype "github.com/gabriel-vasile/mimetype"
-
-	"github.com/datatrails/go-datatrails-common/logger"
 )
 
 var (
@@ -30,7 +28,7 @@ const (
 )
 
 func (azp *Storer) checkContainer(ctx context.Context) error {
-	logger.Sugar.Debugf("Checking container URL %s", azp.containerURL)
+	azp.log.Debugf("Checking container URL %s", azp.containerURL)
 	_, err := azp.containerClient.GetProperties(ctx, nil)
 	if err != nil {
 		return ErrorFromError(err)
@@ -44,7 +42,7 @@ func (azp *Storer) setMetadata(
 	identity string,
 	metadata map[string]string,
 ) error {
-	logger.Sugar.Debugf("setMetadata BlockBlob %s: %v", identity, metadata)
+	azp.log.Debugf("setMetadata BlockBlob %s: %v", identity, metadata)
 
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
 	if err != nil {
@@ -63,7 +61,7 @@ func (azp *Storer) setTags(
 	identity string,
 	tags map[string]string,
 ) error {
-	logger.Sugar.Debugf("setTags BlockBlob %s: %v", identity, tags)
+	azp.log.Debugf("setTags BlockBlob %s: %v", identity, tags)
 
 	blobClient, err := azp.containerClient.NewBlobClient(identity)
 	if err != nil {
@@ -88,11 +86,12 @@ func (azp *Storer) Write(
 	source io.Reader,
 	opts ...Option,
 ) (*WriteResponse, error) {
+	azp.log.Debugf("Write BlockBlob %s", identity)
+
 	err := azp.checkContainer(ctx)
 	if err != nil {
 		return nil, err
 	}
-	logger.Sugar.Debugf("Create BlockBlob %s", identity)
 
 	options := &StorerOptions{}
 	for _, opt := range opts {
@@ -131,11 +130,13 @@ func (azp *Storer) WriteStream(
 	source *http.Request,
 	opts ...Option,
 ) (*WriteResponse, error) {
+
+	azp.log.Debugf("WriteStream BlockBlob %s", identity)
+
 	err := azp.checkContainer(ctx)
 	if err != nil {
 		return nil, err
 	}
-	logger.Sugar.Debugf("Create BlockBlob %s", identity)
 
 	options := &StorerOptions{}
 	for _, opt := range opts {
@@ -151,10 +152,10 @@ func (azp *Storer) writeStream(
 	reader io.Reader,
 	leaseID string,
 ) (*WriteResponse, error) {
-	logger.Sugar.Debugf("write %s", identity)
+	azp.log.Debugf("write %s", identity)
 	blockBlobClient, err := azp.containerClient.NewBlockBlobClient(identity)
 	if err != nil {
-		logger.Sugar.Infof("Cannot get block blob client blob: %v", err)
+		azp.log.Infof("Cannot get block blob client blob: %v", err)
 		return nil, ErrorFromError(err)
 	}
 	blobAccessConditions := azStorageBlob.BlobAccessConditions{
@@ -178,7 +179,7 @@ func (azp *Storer) writeStream(
 		},
 	)
 	if err != nil {
-		logger.Sugar.Infof("Cannot upload blob: %v", err)
+		azp.log.Infof("Cannot upload blob: %v", err)
 		return nil, ErrorFromError(err)
 
 	}
@@ -192,11 +193,11 @@ func (azp *Storer) streamReader(
 	options *StorerOptions,
 ) (*WriteResponse, error) {
 
-	logger.Sugar.Debugf("streamReader: %v", r)
+	azp.log.Debugf("streamReader: %v", r)
 	var err error
 
 	if r.ContentLength < 1 {
-		logger.Sugar.Errorf("No content to be uploaded")
+		azp.log.Infof("No content to be uploaded")
 		return nil, NewStatusError(fmt.Sprintf("no content to be uploaded"), http.StatusBadRequest)
 	}
 	// get the multipart reader
@@ -204,7 +205,7 @@ func (azp *Storer) streamReader(
 	// "request Content-Type isn't multipart/form-data"
 	reader, err := r.MultipartReader()
 	if err != nil {
-		logger.Sugar.Errorf("failed to get multipart reader: %v", err)
+		azp.log.Infof("failed to get multipart reader: %v", err)
 		return nil, NewStatusError(fmt.Sprintf("failed to get multipart reader: %v", err), http.StatusBadRequest)
 	}
 
@@ -217,7 +218,7 @@ func (azp *Storer) streamReader(
 		part, err := reader.NextPart()
 		if err == io.EOF { //nolint https://github.com/golang/go/issues/39155
 			// we've got all of it just exit
-			logger.Sugar.Debugf("got complete file")
+			azp.log.Debugf("got complete file")
 			break
 		}
 
@@ -227,11 +228,11 @@ func (azp *Storer) streamReader(
 		}
 
 		defer part.Close()
-		logger.Sugar.Debugf("uploading %s", part.FileName())
+		azp.log.Debugf("uploading %s", part.FileName())
 
 		if numFiles > 1 {
 			// we got multiple files - bad request
-			logger.Sugar.Infof("only one file expected")
+			azp.log.Infof("only one file expected")
 			return nil, NewStatusError("only one file expected", http.StatusBadRequest)
 		}
 
@@ -258,7 +259,7 @@ func (azp *Storer) streamReader(
 				return nil, copyErr
 			}
 
-			logger.Sugar.Infof("request file size: %d", count)
+			azp.log.Infof("request file size: %d", count)
 
 			if count >= options.sizeLimit {
 				return nil, NewStatusError("filesize exceeds maximum", http.StatusPaymentRequired)
@@ -287,7 +288,7 @@ func (azp *Storer) streamReader(
 			// catenate the header and remaining data to make it look like a new reader
 			uploadData.part = io.MultiReader(header, uploadData.part)
 		}
-		logger.Sugar.Debugf("Mime type is: %s", mimeType)
+		azp.log.Debugf("Mime type is: %s", mimeType)
 
 		// prepare blob
 		resp, err = azp.writeStream(ctx, identity, uploadData, options.leaseID)

--- a/azblob/upload.go
+++ b/azblob/upload.go
@@ -131,8 +131,6 @@ func (azp *Storer) WriteStream(
 	opts ...Option,
 ) (*WriteResponse, error) {
 
-	azp.log.Debugf("WriteStream BlockBlob %s", identity)
-
 	err := azp.checkContainer(ctx)
 	if err != nil {
 		return nil, err
@@ -152,7 +150,7 @@ func (azp *Storer) writeStream(
 	reader io.Reader,
 	leaseID string,
 ) (*WriteResponse, error) {
-	azp.log.Debugf("write %s", identity)
+
 	blockBlobClient, err := azp.containerClient.NewBlockBlobClient(identity)
 	if err != nil {
 		azp.log.Infof("Cannot get block blob client blob: %v", err)

--- a/azbus/disposition.go
+++ b/azbus/disposition.go
@@ -77,8 +77,8 @@ func (r *BatchReceiver) Dispose(ctx context.Context, d Disposition, err error, m
 func abandon(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, err error, msg *ReceivedMessage) {
 	ctx = context.WithoutCancel(ctx)
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "Message.Abandon")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, log, "Message.Abandon")
+	defer span.Close()
 	log.Infof("Abandon Message on DeliveryCount %d: %v", msg.DeliveryCount, err)
 	err1 := r.AbandonMessage(ctx, msg, nil)
 	if err1 != nil {
@@ -91,8 +91,8 @@ func abandon(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, e
 func deadLetter(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, err error, msg *ReceivedMessage) {
 	ctx = context.WithoutCancel(ctx)
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "Message.DeadLetter")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, log, "Message.DeadLetter")
+	defer span.Close()
 	log.Infof("DeadLetter Message: %v", err)
 	options := azservicebus.DeadLetterOptions{
 		Reason: to.Ptr(strings.ToValidUTF8(err.Error(), "!!!")),
@@ -107,8 +107,8 @@ func deadLetter(ctx context.Context, log logger.Logger, r *azservicebus.Receiver
 func complete(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, err error, msg *ReceivedMessage) {
 	ctx = context.WithoutCancel(ctx)
 
-	span, _ := tracing.StartSpanFromContext(ctx, "Message.Complete")
-	defer span.Finish()
+	span, _ := tracing.StartSpanFromContext(ctx, log, "Message.Complete")
+	defer span.Close()
 
 	if err != nil {
 		log.Infof("Complete Message %v", err)
@@ -133,8 +133,8 @@ func complete(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, 
 func reschedule(ctx context.Context, log logger.Logger, r *azservicebus.Receiver, err error, msg *ReceivedMessage) {
 	ctx = context.WithoutCancel(ctx)
 
-	span, _ := tracing.StartSpanFromContext(ctx, "Message.Reschedule")
-	defer span.Finish()
+	span, _ := tracing.StartSpanFromContext(ctx, log, "Message.Reschedule")
+	defer span.Close()
 	log.Infof("Reschedule Message on DeliveryCount %d: %v", msg.DeliveryCount, err)
 }
 

--- a/azbus/receiver.go
+++ b/azbus/receiver.go
@@ -177,7 +177,7 @@ func (r *Receiver) processMessage(ctx context.Context, count int, maxDuration ti
 	// the context wont have a trace span on it yet, so stick with the receiver logger instance
 
 	r.log.Debugf("Processing message %d id %s", count, msg.MessageID)
-	disp, ctx, err := r.handleReceivedMessageWithTracingContext(ctx, msg, handler)
+	disp, ctx, err := r.handleReceivedMessageWithTracingContext(ctx, r.log, msg, handler)
 	r.dispose(ctx, disp, err, msg)
 
 	duration := time.Since(now)

--- a/azbus/tracing.go
+++ b/azbus/tracing.go
@@ -3,56 +3,22 @@ package azbus
 import (
 	"context"
 
+	"github.com/datatrails/go-datatrails-common/spanner"
 	"github.com/datatrails/go-datatrails-common/tracing"
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
-func (r *Receiver) CreateReceivedMessageTracingContext(ctx context.Context, message *ReceivedMessage, handler Handler) (context.Context, opentracing.Span) {
-	// We don't have the tracing span info on the context yet, that is what this function will add
-	// we we log using the reciever logger
-	r.log.Debugf("ContextFromReceivedMessage(): ApplicationProperties %v", message.ApplicationProperties)
-
-	var opts = []opentracing.StartSpanOption{}
-	carrier := opentracing.TextMapCarrier{}
-	// This just gets all the message Application Properties into a string map. That map is then passed into the
-	// open tracing constructor which extracts any bits it is interested in to use to setup the spans etc.
-	// It will ignore anything it doesn't care about. So the filtering of the map is done for us and
-	// we don't need to pre-filter it.
-	for k, v := range message.ApplicationProperties {
-		// Tracing properties will be strings
-		value, ok := v.(string)
-		if ok {
-			carrier.Set(k, value)
-		}
-	}
-	spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, carrier)
-	if err != nil {
-		r.log.Infof("CreateReceivedMessageWithTracingContext(): Unable to extract span context: %v", err)
-	} else {
-		opts = append(opts, opentracing.ChildOf(spanCtx))
-	}
-	span := opentracing.StartSpan("handle message", opts...)
-	ctx = opentracing.ContextWithSpan(ctx, span)
-	return ctx, span
-}
-
-func (r *Receiver) handleReceivedMessageWithTracingContext(ctx context.Context, message *ReceivedMessage, handler Handler) (Disposition, context.Context, error) {
-	ctx, span := r.CreateReceivedMessageTracingContext(ctx, message, handler)
-	defer span.Finish()
+func (r *Receiver) handleReceivedMessageWithTracingContext(ctx context.Context, log Logger, message *ReceivedMessage, handler Handler) (Disposition, context.Context, error) {
+	var span spanner.Spanner
+	span, ctx = tracing.NewSpanWithAttributes(ctx, "Receiver", log, message.ApplicationProperties)
+	defer span.Close()
 	return handler.Handle(ctx, message)
 }
 
-func (s *Sender) updateSendingMesssageForSpan(ctx context.Context, message *OutMessage, span opentracing.Span) {
+func (s *Sender) updateSendingMesssageForSpan(ctx context.Context, message *OutMessage, span spanner.Spanner) {
 	log := tracing.LogFromContext(ctx, s.log)
 	defer log.Close()
 
-	carrier := opentracing.TextMapCarrier{}
-	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.TextMap, carrier)
-	if err != nil {
-		log.Infof("updateSendingMesssageForSpan(): Unable to inject span context: %v", err)
-		return
-	}
-	for k, v := range carrier {
+	for k, v := range span.Attributes(log) {
 		OutMessageSetProperty(message, k, v)
 	}
 	log.Debugf("updateSendingMesssageForSpan(): ApplicationProperties %v", OutMessageProperties(message))

--- a/azkeys/keyvault.go
+++ b/azkeys/keyvault.go
@@ -68,8 +68,8 @@ func (kv *KeyVault) GetLatestKey(
 		return keyvault.KeyBundle{}, err
 	}
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault GetKey")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, logger.Sugar, "KeyVault GetKey")
+	defer span.Close()
 
 	key, err := kvClient.GetKey(ctx, kv.url, keyName, "")
 	if err != nil {
@@ -94,8 +94,8 @@ func (kv *KeyVault) GetKeyVersionsKeys(
 		return []keyvault.KeyBundle{}, err
 	}
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault GetKeyVersions")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, logger.Sugar, "KeyVault GetKeyVersions")
+	defer span.Close()
 
 	pageLimit := int32(1)
 	keyVersions, err := kvClient.GetKeyVersions(ctx, kv.url, keyID, &pageLimit)
@@ -103,7 +103,7 @@ func (kv *KeyVault) GetKeyVersionsKeys(
 		return []keyvault.KeyBundle{}, fmt.Errorf("failed to read key: %w", err)
 	}
 
-	span.Finish()
+	span.Close()
 
 	keyVersionValues := keyVersions.Values()
 
@@ -200,8 +200,8 @@ func (kv *KeyVault) Sign(
 	keyName := GetKeyName(keyID)
 	keyVersion := GetKeyVersion(keyID)
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault Sign")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, logger.Sugar, "KeyVault Sign")
+	defer span.Close()
 
 	signatureb64, err := kvClient.Sign(ctx, kv.url, keyName, keyVersion, params)
 	if err != nil {
@@ -283,8 +283,8 @@ func (kv *KeyVault) Verify(
 		Digest:    &digestStr,
 	}
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault Verify")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, logger.Sugar, "KeyVault Verify")
+	defer span.Close()
 
 	result, err := kvClient.Verify(ctx, kv.url, keyID, keyVersion, params)
 	if err != nil {

--- a/azkeys/secretvault.go
+++ b/azkeys/secretvault.go
@@ -95,8 +95,8 @@ func (k *SecretVault) ReadSecret(
 		return nil, err
 	}
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault GetSecret")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, log, "KeyVault GetSecret")
+	defer span.Close()
 
 	secret, err := kvClient.GetSecret(ctx, k.Name, id, "")
 	if err != nil {
@@ -153,8 +153,8 @@ func (k *SecretVault) ListSecrets(
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	span, ctx := tracing.StartSpanFromContext(ctx, "KeyVault GetSecrets")
-	defer span.Finish()
+	span, ctx := tracing.StartSpanFromContext(ctx, log, "KeyVault GetSecrets")
+	defer span.Close()
 
 	// must be <= 25
 	maxResults := int32(25)
@@ -167,7 +167,7 @@ func (k *SecretVault) ListSecrets(
 		return nil, fmt.Errorf("failed to read secrets: %w", err)
 	}
 
-	span.Finish()
+	span.Close()
 
 	results := map[string]SecretEntry{}
 	for {

--- a/spanner/spanner.go
+++ b/spanner/spanner.go
@@ -1,0 +1,18 @@
+package spanner
+
+import (
+	"net/http"
+
+	"github.com/datatrails/go-datatrails-common/logger"
+)
+
+// this interface is in a separate package such that azblob and tracing packages can share the
+// same interface definition that is returned fro the StartSpanFromContext etc.. methods.
+type Spanner interface {
+	Close()
+	SetTag(string, any)
+	SetSpanHTTPHeader(*http.Request)
+	Attributes(logger.Logger) map[string]any
+	LogField(string, any)
+	TraceID() string
+}

--- a/tracing/logfromcontext.go
+++ b/tracing/logfromcontext.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 
+	"github.com/datatrails/go-datatrails-common/logger"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -12,25 +13,33 @@ import (
 //   - the new logger with a context metadata value for traceID
 //
 // This will be called on entry to a method or a function that has a context.Context.
-func LogFromContext(ctx context.Context, log Logger) Logger {
+func LogFromContext(ctx context.Context, log logger.Logger) logger.Logger {
+	traceID := TraceIDFromContext(ctx, log)
+	if traceID != "" {
+		return log.WithIndex(TraceID, traceID)
+	}
+	return log
+}
+
+func TraceIDFromContext(ctx context.Context, log logger.Logger) string {
 
 	span := opentracing.SpanFromContext(ctx)
 	if span == nil {
 		log.Infof("FromContext: span is nil - this should not happen - the context where this happened is missing tracing content - probably a middleware problem")
-		return log
+		return ""
 	}
 	carrier := opentracing.TextMapCarrier{}
 	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.TextMap, carrier)
 	if err != nil {
 		log.Debugf("FromContext: can't inject span: %v", err)
-		return log
+		return ""
 	}
 
 	traceID, found := carrier[TraceID]
 	if !found || traceID == "" {
 		log.Debugf("%s not found", TraceID)
-		return log
+		return ""
 	}
 
-	return log.WithIndex(TraceID, traceID)
+	return traceID
 }

--- a/tracing/logger.go
+++ b/tracing/logger.go
@@ -1,7 +1,0 @@
-package tracing
-
-import (
-	"github.com/datatrails/go-datatrails-common/logger"
-)
-
-type Logger = logger.Logger

--- a/tracing/spanner.go
+++ b/tracing/spanner.go
@@ -22,7 +22,7 @@ type Spanner interface {
 // the Go compiler treats interfaces defined in separate packages as different even
 // though the signature is identical. So this struct hides the interface and returns a
 // concrete type instead.
-// Conveniently it also hides calls to the opentracing-go pacakage thsu making it
+// Conveniently it also hides calls to the opentracing-go package thsu making it
 // easier to move to opentelemetry later.
 type Span struct {
 	span opentracing.Span

--- a/tracing/spanner.go
+++ b/tracing/spanner.go
@@ -1,0 +1,167 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/datatrails/go-datatrails-common/logger"
+	"github.com/datatrails/go-datatrails-common/spanner"
+	opentracing "github.com/opentracing/opentracing-go"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
+)
+
+type Spanner interface {
+	Close()
+	SetTag(string, any)
+	SetSpanHTTPHeader(http.Request)
+	SetSpanField(string, string)
+	TraceID() string
+}
+
+// Injecting a function StartSpanFomContext that returns an interface does not work as
+// the Go compiler treats interfaces defined in separate packages as different even
+// though the signature is identical. So this struct hides the interface and returns a
+// concrete type instead.
+// Conveniently it also hides calls to the opentracing-go pacakage thsu making it
+// easier to move to opentelemetry later.
+type Span struct {
+	span opentracing.Span
+	log  logger.Logger
+}
+
+func (s *Span) Close() {
+	if s.span != nil {
+		s.span.Finish()
+		s.span = nil
+	}
+}
+
+func (s *Span) SetTag(key string, value any) {
+	if s.span != nil {
+		s.span.SetTag(key, value)
+	}
+}
+
+func (s *Span) SetSpanHTTPHeader(r *http.Request) {
+	// Transmit the span's TraceContext as HTTP headers on our request
+	if s.span != nil {
+		err := opentracing.GlobalTracer().Inject(
+			s.span.Context(),
+			opentracing.HTTPHeaders,
+			opentracing.HTTPHeadersCarrier(r.Header),
+		)
+		if err != nil {
+			s.log.Infof("Tracer.Inject %v", err)
+		}
+	}
+}
+
+func (s *Span) LogField(key string, value any) {
+	if s.span != nil {
+		switch v := value.(type) {
+		case bool:
+			s.span.LogFields(opentracinglog.Bool(key, v))
+		case error:
+			s.span.LogFields(opentracinglog.Error(v))
+		case int:
+			s.span.LogFields(opentracinglog.Int(key, v))
+		case int32:
+			s.span.LogFields(opentracinglog.Int32(key, v))
+		case int64:
+			s.span.LogFields(opentracinglog.Int64(key, v))
+		case uint32:
+			s.span.LogFields(opentracinglog.Uint32(key, v))
+		case uint64:
+			s.span.LogFields(opentracinglog.Uint64(key, v))
+		case float32:
+			s.span.LogFields(opentracinglog.Float32(key, v))
+		case float64:
+			s.span.LogFields(opentracinglog.Float64(key, v))
+		case string:
+			s.span.LogFields(opentracinglog.String(key, v))
+		}
+	}
+}
+
+func valueFromCarrier(carrier opentracing.TextMapCarrier, key string) string {
+	value, found := carrier[key]
+	if !found || value == "" {
+		return ""
+	}
+	return value
+}
+
+func (s *Span) TraceID() string {
+	if s.span == nil {
+		return ""
+	}
+	carrier := opentracing.TextMapCarrier{}
+	err := opentracing.GlobalTracer().Inject(s.span.Context(), opentracing.TextMap, carrier)
+	if err != nil {
+		return ""
+	}
+
+	return valueFromCarrier(carrier, TraceID)
+}
+
+func (s *Span) Attributes(log logger.Logger) map[string]any {
+	var attributes = make(map[string]any)
+	if s.span == nil {
+		return attributes
+	}
+
+	carrier := opentracing.TextMapCarrier{}
+	err := opentracing.GlobalTracer().Inject(s.span.Context(), opentracing.TextMap, carrier)
+	if err != nil {
+		log.Infof("attributes(): Unable to inject span context: %v", err)
+		return attributes
+	}
+	for k, v := range carrier {
+		attributes[k] = v
+	}
+	log.Debugf("Attributes(): %v", attributes)
+	return attributes
+}
+
+// Constructors...
+func NewSpanWithAttributes(ctx context.Context, name string, log logger.Logger, attributes map[string]any) (spanner.Spanner, context.Context) {
+	log.Debugf("NewSpanWithAttributes %s", name)
+	var opts = []opentracing.StartSpanOption{}
+	carrier := opentracing.TextMapCarrier{}
+	// This just gets all the attributes into a string map. That map is then passed into the
+	// open tracing constructor which extracts any bits it is interested in to use to setup the spans etc.
+	// It will ignore anything it doesn't care about. So the filtering of the map is done for us and
+	// we don't need to pre-filter it.
+	for k, v := range attributes {
+		// Tracing properties will be strings
+		value, ok := v.(string)
+		if ok {
+			carrier.Set(k, value)
+		}
+	}
+	spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.TextMap, carrier)
+	if err != nil {
+		log.Infof("NewSpanWithAttributes(): Unable to extract span context: %v", err)
+	} else {
+		opts = append(opts, opentracing.ChildOf(spanCtx))
+	}
+	span := opentracing.StartSpan(name, opts...)
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	return &Span{span: span, log: log}, ctx
+}
+
+func NewSpanContext(ctx context.Context, log logger.Logger, name string) (spanner.Spanner, context.Context) {
+	log.Debugf("NewSpanContext %s", name)
+	span := opentracing.StartSpan(name)
+	if span == nil {
+		return nil, ctx
+	}
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	return &Span{span: span, log: log}, ctx
+}
+
+func StartSpanFromContext(ctx context.Context, log logger.Logger, name string) (spanner.Spanner, context.Context) {
+	log.Debugf("StartSpanFromContext %s", name)
+	span, ctx := opentracing.StartSpanFromContext(ctx, name)
+	return &Span{span: span, log: log}, ctx
+}


### PR DESCRIPTION
```
Testing results

Inspected spans using 'task monitor:tracing' and check that a span 'listBlobsFlat' was present. This is only present if the injection logic has worked.


robot:smoke: RESULTS: Tests 96 , Errors 0 , Failures 0 , Time 50.470
robot:core: RESULTS: Tests 534 , Errors 0 , Failures 0 , Time 180.150
robot:tenancies: RESULTS: Tests 38 , Errors 0 , Failures 0 , Time 57.695
robot:invites: RESULTS: Tests 23 , Errors 0 , Failures 0 , Time 6.578
robot:scitt: RESULTS: Tests 8 , Errors 0 , Failures 0 , Time 141.083
robot:abac: RESULTS: Tests 196 , Errors 0 , Failures 0 , Time 153.159
robot:obac: RESULTS: Tests 117 , Errors 0 , Failures 0 , Time 251.570
robot:slow-cd: RESULTS: Tests 4 , Errors 0 , Failures 0 , Time 24.134
robot:flaky: RESULTS: Tests 4 , Errors 0 , Failures 0 , Time 11.542

playright:api:smoke:   30 passed (2.2m)
playright:api:core:   41 passed (16.5s)
playright:api:app-registrations:   44 passed (20.9s)
playright:api:membership:   69 passed (27.6s)
playright:api:tenancies:   61 passed (26.5s)
```


[AB#10601](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10601)